### PR TITLE
Fix deprecation warning

### DIFF
--- a/emailer-ses.js
+++ b/emailer-ses.js
@@ -1,6 +1,6 @@
 var aws = require('aws-sdk');
-var winston = module.parent.require('winston');
-var meta = module.parent.require('./meta');
+var winston = require.main.require('winston');
+var meta = require.main.require('./src/meta');
 var Emailer = {};
 var ses;
 var fromAddress;


### PR DESCRIPTION
This fixes the startup error:
```
2019-12-19T21:18:05.026Z [4567/100] - warn: [deprecated] requiring core modules with `module.parent.require('./meta')` is deprecated. Please use `require.main.require("./src/<module_name>")` instead.
    at Object.<anonymous> (/home/app/nodebb/node_modules/nodebb-plugin-emailer-ses/emailer-ses.js:3:26)
```

I believe that NodeBB v1.4.5 introduced `require.main.require`, hence the updated compatibility, but I'd love if @barisusakli could help us verify that.